### PR TITLE
nlog(n) solution to concat using divide and conquer

### DIFF
--- a/list_ops.exs
+++ b/list_ops.exs
@@ -12,7 +12,7 @@ defmodule ListOps do
   end
 
   defp _count([],acc), do: acc
-  defp _count([h|t], acc), do: _count(t,acc + 1)
+  defp _count([_h|t], acc), do: _count(t, acc + 1)
 
   @spec reverse(list) :: list
   def reverse(l) do
@@ -46,7 +46,7 @@ defmodule ListOps do
     _reduce(l, acc, f)
   end
 
-  defp _reduce([], acc, f), do: acc
+  defp _reduce([], acc, _f), do: acc
   defp _reduce([h|t], acc, f), do: _reduce(t, f.(h, acc), f)
 
   @spec append(list, list) :: list
@@ -59,13 +59,15 @@ defmodule ListOps do
 
   @spec concat([[any]]) :: [any]
   def concat(ll) do
-    _concat(ll, [], 0)
+    cond do
+      ll == [] -> []
+      count(ll) == 1 -> hd(ll)
+      true -> _concat(Enum.split(ll, div(count(ll), 2)))
+    end
   end
 
-  defp _concat(_, acc, 1000000), do: acc
-  defp _concat([], acc, _n), do: acc
-  defp _concat([h|t], acc, n) do
-    _concat(t, append(acc, h), n + 1)
+  defp _concat({left, right}) do
+    append(concat(left), concat(right))
   end
 
 end

--- a/list_ops_test.exs
+++ b/list_ops_test.exs
@@ -12,127 +12,134 @@ defmodule ListOpsTest do
 
   defp odd?(n), do: rem(n, 2) == 1
 
-  @tag :pending
+  # @tag :pending
   test "count of empty list" do
     assert L.count([]) == 0
   end
 
-  @tag :pending
+  # @tag :pending
   test "count of normal list" do
     assert L.count([1,3,5,7]) == 4
   end
 
-  @tag :pending
+  # @tag :pending
   test "count of huge list" do
     assert L.count(Enum.to_list(1..1_000_000)) == 1_000_000
   end
 
-  @tag :pending
+  # @tag :pending
   test "reverse of empty list" do
     assert L.reverse([]) == []
   end
 
-  @tag :pending
+  # @tag :pending
   test "reverse of normal list" do
     assert L.reverse([1,3,5,7]) == [7,5,3,1]
   end
 
-  @tag :pending
+  # @tag :pending
   test "reverse of huge list" do
     assert L.reverse(Enum.to_list(1..1_000_000)) == Enum.to_list(1_000_000..1)
   end
 
-  @tag :pending
+  # @tag :pending
   test "map of empty list" do
     assert L.map([], &(&1+1)) == []
   end
 
-  @tag :pending
+  # @tag :pending
   test "map of normal list" do
     assert L.map([1,3,5,7], &(&1+1)) == [2,4,6,8]
   end
 
-  @tag :pending
+  # @tag :pending
   test "map of huge list" do
     assert L.map(Enum.to_list(1..1_000_000), &(&1+1)) ==
       Enum.to_list(2..1_000_001)
   end
 
-  @tag :pending
+  # @tag :pending
   test "filter of empty list" do
     assert L.filter([], &odd?/1) == []
   end
 
-  @tag :pending
+  # @tag :pending
   test "filter of normal list" do
     assert L.filter([1,2,3,4], &odd?/1) == [1,3]
   end
 
-  @tag :pending
+  # @tag :pending
   test "filter of huge list" do
     assert L.filter(Enum.to_list(1..1_000_000), &odd?/1) ==
       Enum.map(1..500_000, &(&1*2-1))
   end
 
-  @tag :pending
+  # @tag :pending
   test "reduce of empty list" do
     assert L.reduce([], 0, &(&1+&2)) == 0
   end
 
-  @tag :pending
+  # @tag :pending
   test "reduce of normal list" do
     assert L.reduce([1,2,3,4], -3, &(&1+&2)) == 7
   end
 
-  @tag :pending
+  # @tag :pending
   test "reduce of huge list" do
     assert L.reduce(Enum.to_list(1..1_000_000), 0, &(&1+&2)) ==
       Enum.reduce(1..1_000_000, 0, &(&1+&2))
   end
 
-  @tag :pending
+  # @tag :pending
   test "reduce with non-commutative function" do
     assert L.reduce([1,2,3,4], 10, fn x, acc -> acc - x end) == 0
   end
 
-  @tag :pending
+  # @tag :pending
   test "append of empty lists" do
     assert L.append([], []) == []
   end
 
-  @tag :pending
+  # @tag :pending
   test "append of empty and non-empty list" do
     assert L.append([], [1,2,3,4]) == [1,2,3,4]
   end
 
-  @tag :pending
+  # @tag :pending
   test "append of non-empty and empty list" do
     assert L.append([1,2,3,4], []) == [1,2,3,4]
   end
 
-  @tag :pending
+  # @tag :pending
   test "append of non-empty lists" do
     assert L.append([1,2,3], [4,5]) == [1,2,3,4,5]
   end
 
+  # @tag :pending
   test "append of list with inside lists" do
     assert L.append([[1, 2], 3], [4, 5]) == [[1, 2], 3, 4, 5]
   end
 
-  @tag :pending
+  # @tag :pending
   test "append of huge lists" do
     assert L.append(Enum.to_list(1..1_000_000), Enum.to_list(1_000_001..2_000_000)) ==
       Enum.to_list(1..2_000_000)
   end
 
-  @tag :pending
+  # @tag :pending
   test "concat of empty list of lists" do
     assert L.concat([]) == []
   end
 
-  @tag :pending
+  # @tag :pending
   test "concat of normal list of lists" do
     assert L.concat([[1,2],[3],[],[4,5,6]]) == [1,2,3,4,5,6]
+  end
+
+  # @tag :pending
+  test "concat of small list of small lists" do
+    assert L.concat(Enum.map(1..10, &[&1])) ==
+      Enum.to_list(1..10)
   end
 
   # @tag :pending


### PR DESCRIPTION
solved concat via divide and conquer strategy (building smaller list up into bigger lists in order to reduce the number of `reverse`, `count`, and `append` operations